### PR TITLE
fix: corrigir migração Room e loading da IA

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,8 +13,8 @@ android {
         applicationId "com.paradoxo.amadeus"
         minSdk 21
         targetSdk 35
-        versionCode 26
-        versionName "3.0.0-beta-01"
+        versionCode 28
+        versionName "3.0.0 | Alpha 1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/schemas/com.paradoxo.amadeus.dao.room.AmadeusDatabase/5.json
+++ b/app/schemas/com.paradoxo.amadeus.dao.room.AmadeusDatabase/5.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 5,
-    "identityHash": "cd2acc5cd0aad3ecc5652dcbb1a78334",
+    "identityHash": "0c1e43f32f96bff9ccc943caa27b4912",
     "entities": [
       {
         "tableName": "autor",
@@ -91,7 +91,7 @@
       },
       {
         "tableName": "sentenca",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `chave` TEXT, `respostas` TEXT, `acao` TEXT, `tipo_item` INTEGER, `idBanco` TEXT, PRIMARY KEY(`id`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `chave` TEXT, `respostas` TEXT, `acao` TEXT, `tipo_item` INTEGER, `idBanco` TEXT)",
         "fields": [
           {
             "fieldPath": "id",
@@ -126,7 +126,7 @@
           }
         ],
         "primaryKey": {
-          "autoGenerate": false,
+          "autoGenerate": true,
           "columnNames": [
             "id"
           ]
@@ -134,7 +134,7 @@
       },
       {
         "tableName": "historico_sentenca",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `chave` TEXT, `respostas` TEXT, `acao` TEXT, `tipo_item` INTEGER, PRIMARY KEY(`id`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `chave` TEXT, `respostas` TEXT, `acao` TEXT, `tipo_item` INTEGER)",
         "fields": [
           {
             "fieldPath": "id",
@@ -164,7 +164,7 @@
           }
         ],
         "primaryKey": {
-          "autoGenerate": false,
+          "autoGenerate": true,
           "columnNames": [
             "id"
           ]
@@ -172,7 +172,7 @@
       },
       {
         "tableName": "entidade",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `nome` TEXT, `significados` TEXT, `sinonimos` TEXT, `atributos` TEXT, `idBanco` TEXT, PRIMARY KEY(`id`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `nome` TEXT, `significados` TEXT, `sinonimos` TEXT, `atributos` TEXT, `idBanco` TEXT)",
         "fields": [
           {
             "fieldPath": "id",
@@ -207,7 +207,7 @@
           }
         ],
         "primaryKey": {
-          "autoGenerate": false,
+          "autoGenerate": true,
           "columnNames": [
             "id"
           ]
@@ -216,7 +216,7 @@
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'cd2acc5cd0aad3ecc5652dcbb1a78334')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '0c1e43f32f96bff9ccc943caa27b4912')"
     ]
   }
 }

--- a/app/src/main/assets/SentencasHistoricoPadrao.json
+++ b/app/src/main/assets/SentencasHistoricoPadrao.json
@@ -34,7 +34,7 @@
     "id": 0,
     "respostas": [
       "Nos avalie na Google Play Store e deixe seu comentário",
-      "Que dar uma ideia para o app?"
+      "Quer dar uma ideia para o app?"
     ],
     "tipo_item": 3
   }

--- a/app/src/main/java/com/paradoxo/amadeus/activity/MainActivity.kt
+++ b/app/src/main/java/com/paradoxo/amadeus/activity/MainActivity.kt
@@ -147,19 +147,20 @@ class MainActivity : AppCompatActivity(), DialogSimples.FragmentDialogInterface 
             recyclerView.smoothScrollToPosition(adapter.itemCount)
         }
 
+        adapter.add(sentenca)
+        if (sentenca.tipo_item == ItemEnum.USUARIO.ordinal) {
+            adapter.add(Sentenca(ITEM_LOAD.ordinal))
+        } else {
+            textoParaVoz.configurarFalaIA(sentenca.respostas[0])
+        }
+        Handler(mainLooper).postDelayed({ recyclerView.smoothScrollToPosition(adapter.itemCount) }, 250)
+
         lifecycleScope.launch(Dispatchers.IO) {
             val id = AmadeusDatabase.getInstance(this@MainActivity)
                 .sentencaDAO().inserirHistorico(sentenca.toHistoricoEntity())
             withContext(Dispatchers.Main) {
                 idUltimoHistoricoGravado = id
                 sentenca.id = id.toString()
-                adapter.add(sentenca)
-                if (sentenca.tipo_item == ItemEnum.USUARIO.ordinal) {
-                    adapter.add(Sentenca(ITEM_LOAD.ordinal))
-                } else {
-                    textoParaVoz.configurarFalaIA(sentenca.respostas[0])
-                }
-                Handler(mainLooper).postDelayed({ recyclerView.smoothScrollToPosition(adapter.itemCount) }, 250)
             }
         }
     }

--- a/app/src/main/java/com/paradoxo/amadeus/activity/SobreActivity.kt
+++ b/app/src/main/java/com/paradoxo/amadeus/activity/SobreActivity.kt
@@ -36,7 +36,7 @@ class SobreActivity : AppCompatActivity() {
     private fun carregarTextoVersao() {
         try {
             val pInfo = packageManager.getPackageInfo(packageName, 0)
-            val versao = getString(R.string.versao) + " " + pInfo.versionName
+            val versao = getString(R.string.versao) + " " + pInfo.versionName + " | " + pInfo.versionCode
             findViewById<TextView>(R.id.versaoTextView).text = versao
         } catch (e: PackageManager.NameNotFoundException) {
             e.printStackTrace()

--- a/app/src/main/java/com/paradoxo/amadeus/adapter/AdapterMaisDeUmItem.kt
+++ b/app/src/main/java/com/paradoxo/amadeus/adapter/AdapterMaisDeUmItem.kt
@@ -64,7 +64,7 @@ class AdapterMaisDeUmItem(val itens: MutableList<Sentenca>) : RecyclerView.Adapt
     fun setOnItemClickListener(listener: OnItemClickListener) { onItemClickListener = listener }
     fun setOnLongClickListener(listener: OnLongClickListener) { onLongClickListener = listener }
 
-    fun add(sentenca: Sentenca) { itens.add(sentenca); notifyItemInserted(itemCount) }
+    fun add(sentenca: Sentenca) { itens.add(sentenca); notifyItemInserted(itens.lastIndex) }
     fun remove(position: Int) { itens.removeAt(position); notifyItemRemoved(position) }
     fun add(sentenca: Sentenca, posi: Int) { itens.add(posi, sentenca); notifyItemChanged(posi, sentenca) }
     fun addAll(novos: List<Sentenca>) { itens.addAll(novos); notifyDataSetChanged() }

--- a/app/src/main/java/com/paradoxo/amadeus/dao/room/AmadeusDatabase.kt
+++ b/app/src/main/java/com/paradoxo/amadeus/dao/room/AmadeusDatabase.kt
@@ -109,7 +109,7 @@ abstract class AmadeusDatabase : RoomDatabase() {
             private fun migrarSentenca(db: SupportSQLiteDatabase) {
                 db.execSQL("""
                     CREATE TABLE sentenca_new (
-                        id        INTEGER PRIMARY KEY NOT NULL,
+                        id        INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
                         chave     TEXT,
                         respostas TEXT,
                         acao      TEXT,
@@ -120,7 +120,15 @@ abstract class AmadeusDatabase : RoomDatabase() {
                 db.execSQL("""
                     INSERT INTO sentenca_new (id, chave, respostas, acao, tipo_item, idBanco)
                     SELECT id, chave, respostas, acao, tipo_item, idBanco FROM sentenca
+                    WHERE id IS NOT NULL AND id > 0
                 """.trimIndent())
+                
+                // Preserva o contador AUTOINCREMENT
+                db.execSQL("""
+                    INSERT OR REPLACE INTO sqlite_sequence (name, seq)
+                    VALUES ('sentenca_new', (SELECT COALESCE(MAX(id), 0) FROM sentenca_new))
+                """.trimIndent())
+                
                 db.execSQL("DROP TABLE sentenca")
                 db.execSQL("ALTER TABLE sentenca_new RENAME TO sentenca")
             }
@@ -129,7 +137,7 @@ abstract class AmadeusDatabase : RoomDatabase() {
             private fun migrarHistoricoSentenca(db: SupportSQLiteDatabase) {
                 db.execSQL("""
                     CREATE TABLE historico_sentenca_new (
-                        id        INTEGER PRIMARY KEY NOT NULL,
+                        id        INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
                         chave     TEXT,
                         respostas TEXT,
                         acao      TEXT,
@@ -139,7 +147,15 @@ abstract class AmadeusDatabase : RoomDatabase() {
                 db.execSQL("""
                     INSERT INTO historico_sentenca_new (id, chave, respostas, acao, tipo_item)
                     SELECT id, chave, respostas, acao, tipo_item FROM historico_sentenca
+                    WHERE id IS NOT NULL AND id > 0
                 """.trimIndent())
+                
+                // Preserva o contador AUTOINCREMENT
+                db.execSQL("""
+                    INSERT OR REPLACE INTO sqlite_sequence (name, seq)
+                    VALUES ('historico_sentenca_new', (SELECT COALESCE(MAX(id), 0) FROM historico_sentenca_new))
+                """.trimIndent())
+                
                 db.execSQL("DROP TABLE historico_sentenca")
                 db.execSQL("ALTER TABLE historico_sentenca_new RENAME TO historico_sentenca")
             }
@@ -149,7 +165,7 @@ abstract class AmadeusDatabase : RoomDatabase() {
             private fun migrarEntidade(db: SupportSQLiteDatabase) {
                 db.execSQL("""
                     CREATE TABLE entidade_new (
-                        id          INTEGER PRIMARY KEY NOT NULL,
+                        id          INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
                         nome        TEXT,
                         significados TEXT,
                         sinonimos   TEXT,
@@ -161,7 +177,15 @@ abstract class AmadeusDatabase : RoomDatabase() {
                     INSERT INTO entidade_new (id, nome, significados, sinonimos, atributos, idBanco)
                     SELECT id, nome, significados, sinonimos, CAST(atributos AS TEXT), idBanco
                     FROM entidade
+                    WHERE id IS NOT NULL AND id > 0
                 """.trimIndent())
+                
+                // Preserva o contador AUTOINCREMENT
+                db.execSQL("""
+                    INSERT OR REPLACE INTO sqlite_sequence (name, seq)
+                    VALUES ('entidade_new', (SELECT COALESCE(MAX(id), 0) FROM entidade_new))
+                """.trimIndent())
+                
                 db.execSQL("DROP TABLE entidade")
                 db.execSQL("ALTER TABLE entidade_new RENAME TO entidade")
             }

--- a/app/src/main/java/com/paradoxo/amadeus/dao/room/AutorRoomDAO.kt
+++ b/app/src/main/java/com/paradoxo/amadeus/dao/room/AutorRoomDAO.kt
@@ -6,7 +6,7 @@ import com.paradoxo.amadeus.dao.room.entities.AutorEntity
 @Dao
 interface AutorRoomDAO {
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun inserir(autor: AutorEntity): Long
 
     @Update

--- a/app/src/main/java/com/paradoxo/amadeus/dao/room/EntidadeRoomDAO.kt
+++ b/app/src/main/java/com/paradoxo/amadeus/dao/room/EntidadeRoomDAO.kt
@@ -6,7 +6,7 @@ import com.paradoxo.amadeus.dao.room.entities.EntidadeEntity
 @Dao
 interface EntidadeRoomDAO {
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun inserir(entidade: EntidadeEntity): Long
 
     @Update

--- a/app/src/main/java/com/paradoxo/amadeus/dao/room/MensagemRoomDAO.kt
+++ b/app/src/main/java/com/paradoxo/amadeus/dao/room/MensagemRoomDAO.kt
@@ -15,7 +15,7 @@ data class MensagemComResposta(
 @Dao
 interface MensagemRoomDAO {
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun inserir(mensagem: MensagemEntity): Long
 
     // Atualiza apenas fk_resposta de uma mensagem já inserida (par pergunta→resposta)

--- a/app/src/main/java/com/paradoxo/amadeus/dao/room/SentencaRoomDAO.kt
+++ b/app/src/main/java/com/paradoxo/amadeus/dao/room/SentencaRoomDAO.kt
@@ -9,7 +9,7 @@ interface SentencaRoomDAO {
 
     // ── sentenca ──────────────────────────────────────────────────────────────
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun inserir(sentenca: SentencaEntity): Long
 
     @Update
@@ -41,7 +41,7 @@ interface SentencaRoomDAO {
 
     // ── historico_sentenca ────────────────────────────────────────────────────
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun inserirHistorico(sentenca: HistoricoSentencaEntity): Long
 
     @Delete

--- a/app/src/main/java/com/paradoxo/amadeus/dao/room/entities/EntidadeEntity.kt
+++ b/app/src/main/java/com/paradoxo/amadeus/dao/room/entities/EntidadeEntity.kt
@@ -7,7 +7,7 @@ import androidx.room.PrimaryKey
 // atributos era INTEGER no schema original mas armazenava JSON — corrigido para TEXT na Migration 4→5
 @Entity(tableName = "entidade")
 data class EntidadeEntity(
-    @PrimaryKey val id: Int,
+    @PrimaryKey(autoGenerate = true) val id: Int = 0,
     val nome: String?,
     val significados: String?,
     val sinonimos: String?,

--- a/app/src/main/java/com/paradoxo/amadeus/dao/room/entities/HistoricoSentencaEntity.kt
+++ b/app/src/main/java/com/paradoxo/amadeus/dao/room/entities/HistoricoSentencaEntity.kt
@@ -5,7 +5,7 @@ import androidx.room.PrimaryKey
 
 @Entity(tableName = "historico_sentenca")
 data class HistoricoSentencaEntity(
-    @PrimaryKey val id: Int,
+    @PrimaryKey(autoGenerate = true) val id: Int = 0,
     val chave: String?,
     val respostas: String?,
     val acao: String?,

--- a/app/src/main/java/com/paradoxo/amadeus/dao/room/entities/SentencaEntity.kt
+++ b/app/src/main/java/com/paradoxo/amadeus/dao/room/entities/SentencaEntity.kt
@@ -6,7 +6,7 @@ import androidx.room.PrimaryKey
 // respostas e acao são JSON serializado — convertidos via Converters.kt
 @Entity(tableName = "sentenca")
 data class SentencaEntity(
-    @PrimaryKey val id: Int,
+    @PrimaryKey(autoGenerate = true) val id: Int = 0,
     val chave: String?,
     val respostas: String?,
     val acao: String?,


### PR DESCRIPTION
## O que foi corrigido
- Ajusta a migração Room para persistir corretamente mensagens e sentenças
- Corrige auto-incremento e evita sobrescrita de registros
- Remove corretamente o ITEM_LOAD após a resposta da IA
- Ajusta o notify do adapter para inserir itens na posição correta

## Validação
- Build validado com sucesso
- Schema v5 exportado corretamente